### PR TITLE
feat: reinput contact form after failed to submit

### DIFF
--- a/libs/ui/src/containers/widgets/contact-form-widget/ContactFormWidget.machine.tsx
+++ b/libs/ui/src/containers/widgets/contact-form-widget/ContactFormWidget.machine.tsx
@@ -15,7 +15,7 @@ type State =
   | { type: 'formReady'; formValues: FormValues }
   | { type: 'creating'; formValues: FormValues }
   | { type: 'updating'; formValues: FormValues; id: number }
-  | { type: 'submittingError'; message: string }
+  | { type: 'submittingError'; formValues: FormValues; message: string }
   | { type: 'submittingSuccess'; formValues: FormValues };
 
 type Action =
@@ -27,7 +27,8 @@ type Action =
   | { type: 'CREATE' }
   | { type: 'UPDATE'; id: number }
   | { type: 'SUBMIT_SUCCESS' }
-  | { type: 'SUBMIT_ERROR'; message: string };
+  | { type: 'SUBMIT_ERROR'; message: string }
+  | { type: 'REINPUT' };
 
 const reducer = (state: State, action: Action): State => {
   return match<[State, Action], State>([state, action])
@@ -73,10 +74,14 @@ const reducer = (state: State, action: Action): State => {
       type: 'submittingSuccess',
       formValues: state.formValues,
     }))
-    .with([{ type: 'creating' }, { type: 'SUBMIT_ERROR' }], ([_, action]) => ({
-      type: 'submittingError',
-      message: action.message,
-    }))
+    .with(
+      [{ type: 'creating' }, { type: 'SUBMIT_ERROR' }],
+      ([state, action]) => ({
+        type: 'submittingError',
+        message: action.message,
+        formValues: state.formValues,
+      })
+    )
     .with([{ type: 'formReady' }, { type: 'UPDATE' }], ([state, action]) => ({
       type: 'updating',
       formValues: state.formValues,
@@ -86,9 +91,17 @@ const reducer = (state: State, action: Action): State => {
       type: 'submittingSuccess',
       formValues: state.formValues,
     }))
-    .with([{ type: 'updating' }, { type: 'SUBMIT_ERROR' }], ([_, action]) => ({
-      type: 'submittingError',
-      message: action.message,
+    .with(
+      [{ type: 'updating' }, { type: 'SUBMIT_ERROR' }],
+      ([state, action]) => ({
+        type: 'submittingError',
+        message: action.message,
+        formValues: state.formValues,
+      })
+    )
+    .with([{ type: 'submittingError' }, { type: 'REINPUT' }], ([state]) => ({
+      type: 'formReady',
+      formValues: state.formValues,
     }))
     .otherwise(() => state);
 };

--- a/libs/ui/src/containers/widgets/contact-form-widget/ContactFormWidget.tsx
+++ b/libs/ui/src/containers/widgets/contact-form-widget/ContactFormWidget.tsx
@@ -1,5 +1,5 @@
 import { ErrorView, Form, FormProps, Skeleton } from '../../../presentations';
-import { AlertDialog, YStack } from 'tamagui';
+import { YStack, Dialog } from 'tamagui';
 import { match } from 'ts-pattern';
 import { GetContactByID } from '../../../domains/';
 import {
@@ -41,18 +41,13 @@ export const ContactFormWidget = (props: ContactFormWidgetProps) => {
 
   function getFieldValue(fieldName: keyof FormValues) {
     return match(state)
-      .with(
-        { type: 'idle' },
-        { type: 'loading' },
-        { type: 'error' },
-        { type: 'submittingError' },
-        () => ''
-      )
+      .with({ type: 'idle' }, { type: 'loading' }, { type: 'error' }, () => '')
       .with(
         { type: 'formReady' },
         { type: 'creating' },
         { type: 'updating' },
         { type: 'submittingSuccess' },
+        { type: 'submittingError' },
         (state) => state.formValues[fieldName]
       )
       .exhaustive();
@@ -116,25 +111,38 @@ export const ContactFormWidget = (props: ContactFormWidgetProps) => {
       .with({ type: 'submittingSuccess' }, () => (
         <>
           <Form fields={fields} />
-          <AlertDialog>
-            <AlertDialog.Description>
-              {props.variant.type === 'create'
-                ? 'Successfully create data'
-                : 'Successfully update data'}
-            </AlertDialog.Description>
-          </AlertDialog>
+          <Dialog open>
+            <Dialog.Portal>
+              <Dialog.Overlay opacity={0.5} />
+              <Dialog.Content>
+                <Dialog.Description>
+                  {props.variant.type === 'create'
+                    ? 'Successfully create data'
+                    : 'Successfully update data'}
+                </Dialog.Description>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog>
         </>
       ))
       .with({ type: 'submittingError' }, () => (
         <>
           <Form fields={fields} />
-          <AlertDialog>
-            <AlertDialog.Description>
-              {props.variant.type === 'create'
-                ? 'Failed to create data'
-                : 'Failed to update data'}
-            </AlertDialog.Description>
-          </AlertDialog>
+          <Dialog open>
+            <Dialog.Portal>
+              <Dialog.Overlay
+                opacity={0.5}
+                onPress={() => dispatch({ type: 'REINPUT' })}
+              />
+              <Dialog.Content>
+                <Dialog.Description>
+                  {props.variant.type === 'create'
+                    ? 'Failed to create data'
+                    : 'Failed to update data'}
+                </Dialog.Description>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog>
         </>
       ))
       .exhaustive();


### PR DESCRIPTION
Previously, if we fail to submit the contact data, we are stuck in the `submittingError` state forever : 
https://www.loom.com/share/93784329ba1640d3bfc07ba0bc0bfb8f
We can't change the input or submit the form

Thus, to solve that issue, we add new action called `REINPUT` to navigate from the `submittingError` state to the `formReady` state and solve the issue : 
https://www.loom.com/share/dcff57433b3b4919923572343accf8b8
